### PR TITLE
RemotePlayerManager port (from Monumenta Network Chat)

### DIFF
--- a/src/main/java/com/playmonumenta/networkrelay/CustomLogger.java
+++ b/src/main/java/com/playmonumenta/networkrelay/CustomLogger.java
@@ -1,17 +1,27 @@
 package com.playmonumenta.networkrelay;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CustomLogger extends Logger {
+	private static @MonotonicNonNull CustomLogger INSTANCE = null;
+
 	private final Logger mLogger;
 	private Level mLevel;
 
 	public CustomLogger(Logger logger, Level level) {
 		super(logger.getName(), logger.getResourceBundleName());
+		INSTANCE = this;
 		mLogger = logger;
 		mLevel = level;
+	}
+
+	public static Optional<CustomLogger> getInstance() {
+		return Optional.ofNullable(INSTANCE);
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/CustomLogger.java
+++ b/src/main/java/com/playmonumenta/networkrelay/CustomLogger.java
@@ -5,7 +5,6 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.jetbrains.annotations.Nullable;
 
 public class CustomLogger extends Logger {
 	private static @MonotonicNonNull CustomLogger INSTANCE = null;

--- a/src/main/java/com/playmonumenta/networkrelay/GatherRemotePlayerDataEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/GatherRemotePlayerDataEvent.java
@@ -1,0 +1,59 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class GatherRemotePlayerDataEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+
+	private final Map<String, JsonObject> mPluginData = new HashMap<>();
+
+	/**
+	 * Include data in the player's plugin data (that should be retrievable for this shard).
+	 *
+	 * @param pluginId A unique string key identifying this plugin.
+	 * @param key The key of this piece of data.
+	 * @param data The data to be included.
+	 */
+	public void addPluginData(String pluginId, String key, JsonObject data) {
+		if  (mPluginData.containsKey(pluginId)) {
+			JsonObject root = mPluginData.get(pluginId);
+			root.add(key, data);
+			return;
+		}
+		JsonObject root = new JsonObject();
+		root.add(key, data);
+		mPluginData.put(pluginId, root);
+	}
+
+	/**
+	 * Sets the plugin data that should be retrievable for this shard
+	 *
+	 * @param pluginId A unique string key identifying this plugin.
+	 * @param data The data to save.
+	 */
+	public void setPluginData(String pluginId, JsonObject data) {
+        mPluginData.remove(pluginId);
+		mPluginData.put(pluginId, data);
+	}
+
+	/**
+	 * Gets the plugin data already registered
+	 */
+	public Map<String, JsonObject> getPluginData() {
+		return mPluginData;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/GatherRemotePlayerDataEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/GatherRemotePlayerDataEvent.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class GatherRemotePlayerDataEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
@@ -16,11 +15,11 @@ public class GatherRemotePlayerDataEvent extends Event {
 	 * Include data in the player's plugin data (that should be retrievable for this shard).
 	 *
 	 * @param pluginId A unique string key identifying this plugin.
-	 * @param key The key of this piece of data.
-	 * @param data The data to be included.
+	 * @param key      The key of this piece of data.
+	 * @param data     The data to be included.
 	 */
 	public void addPluginData(String pluginId, String key, JsonObject data) {
-		if  (mPluginData.containsKey(pluginId)) {
+		if (mPluginData.containsKey(pluginId)) {
 			JsonObject root = mPluginData.get(pluginId);
 			root.add(key, data);
 			return;
@@ -34,22 +33,22 @@ public class GatherRemotePlayerDataEvent extends Event {
 	 * Sets the plugin data that should be retrievable for this shard
 	 *
 	 * @param pluginId A unique string key identifying this plugin.
-	 * @param data The data to save.
+	 * @param data     The data to save.
 	 */
 	public void setPluginData(String pluginId, JsonObject data) {
-        mPluginData.remove(pluginId);
+		mPluginData.remove(pluginId);
 		mPluginData.put(pluginId, data);
 	}
 
 	/**
-	 * Gets the plugin data already registered
+	 * Gets the already registered plugin data
 	 */
 	public Map<String, JsonObject> getPluginData() {
 		return mPluginData;
 	}
 
 	@Override
-	public @NotNull HandlerList getHandlers() {
+	public HandlerList getHandlers() {
 		return handlers;
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
@@ -40,7 +40,6 @@ public class NetworkRelay extends JavaPlugin {
 		long defaultTTL = config.mDefaultTtl;
 
 		Bukkit.getServer().getPluginManager().registerEvents(new NetworkMessageListener(serverAddress), this);
-		Bukkit.getServer().getPluginManager().registerEvents(RemotePlayerManager.getInstance(), this);
 
 		/* Start relay components */
 		BroadcastCommand.setEnabled(broadcastCommandSendingEnabled);
@@ -66,6 +65,10 @@ public class NetworkRelay extends JavaPlugin {
 				mRabbitMQManager.setServerFinishedStarting();
 			}
 		}, 5);
+
+		//Loaded last to avoid issues where it not being able to load the shard would cause it to fail.
+		Bukkit.getServer().getPluginManager().registerEvents(RemotePlayerManagerPaper.getInstance(), this);
+		RemotePlayerAPI.init(RemotePlayerManagerPaper.getInstance());
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
@@ -37,6 +37,7 @@ public class NetworkRelay extends JavaPlugin {
 		long defaultTTL = config.mDefaultTtl;
 
 		Bukkit.getServer().getPluginManager().registerEvents(new NetworkMessageListener(serverAddress), this);
+		Bukkit.getServer().getPluginManager().registerEvents(new RemotePlayerManager(this), this);
 
 		/* Start relay components */
 		BroadcastCommand.setEnabled(broadcastCommandSendingEnabled);

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 public class NetworkRelay extends JavaPlugin {
+	private static @Nullable NetworkRelay INSTANCE = null;
 	private @Nullable RabbitMQManager mRabbitMQManager = null;
 	private @Nullable BroadcastCommand mBroadcastCommand = null;
 	private @Nullable CustomLogger mLogger = null;
@@ -23,6 +24,8 @@ public class NetworkRelay extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
+		INSTANCE = this;
+
 		File configFile = new File(getDataFolder(), "config.yml");
 
 		BukkitConfig config = new BukkitConfig(getLogger(), configFile, getClass(), "/default_config.yml");
@@ -37,7 +40,7 @@ public class NetworkRelay extends JavaPlugin {
 		long defaultTTL = config.mDefaultTtl;
 
 		Bukkit.getServer().getPluginManager().registerEvents(new NetworkMessageListener(serverAddress), this);
-		Bukkit.getServer().getPluginManager().registerEvents(new RemotePlayerManager(), this);
+		Bukkit.getServer().getPluginManager().registerEvents(RemotePlayerManager.getInstance(), this);
 
 		/* Start relay components */
 		BroadcastCommand.setEnabled(broadcastCommandSendingEnabled);
@@ -70,6 +73,15 @@ public class NetworkRelay extends JavaPlugin {
 		if (mRabbitMQManager != null) {
 			mRabbitMQManager.stop();
 		}
+		INSTANCE = null;
+		getServer().getScheduler().cancelTasks(this);
+	}
+
+	public static NetworkRelay getInstance() {
+		if (INSTANCE == null) {
+			throw new RuntimeException("NetworkRelay has not been initialized yet.");
+		}
+		return INSTANCE;
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelay.java
@@ -37,7 +37,7 @@ public class NetworkRelay extends JavaPlugin {
 		long defaultTTL = config.mDefaultTtl;
 
 		Bukkit.getServer().getPluginManager().registerEvents(new NetworkMessageListener(serverAddress), this);
-		Bukkit.getServer().getPluginManager().registerEvents(new RemotePlayerManager(this), this);
+		Bukkit.getServer().getPluginManager().registerEvents(new RemotePlayerManager(), this);
 
 		/* Start relay components */
 		BroadcastCommand.setEnabled(broadcastCommandSendingEnabled);

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -2,6 +2,8 @@ package com.playmonumenta.networkrelay;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.jetbrains.annotations.Nullable;
@@ -99,48 +101,60 @@ public class NetworkRelayAPI {
 		return getInstance().getOnlineShardNames();
 	}
 
-	public static String[] getOnlinePlayerNames() {
-			RemotePlayerManager manager = RemotePlayerManager.getInstance();
-			if (manager == null) {
-				return new String[]{};
-			}
-			return manager.getAllOnlinePlayersName();
-	}
-
-	@Nullable
-	public static String getPlayerShard(String playerName) {
+	public static Set<String> getOnlinePlayerNames(boolean visibleOnly) {
 		RemotePlayerManager manager = RemotePlayerManager.getInstance();
 		if (manager == null) {
-			return null;
+			return new HashSet<>();
 		}
-		return manager.getPlayerShard(playerName);
+		return manager.getAllOnlinePlayersName(visibleOnly);
 	}
 
-	@Nullable
-	public static String getPlayerShard(UUID playerUuid) {
+	public static Optional<String> getPlayerShard(String playerName) {
 		RemotePlayerManager manager = RemotePlayerManager.getInstance();
 		if (manager == null) {
-			return null;
+			return Optional.empty();
 		}
-		return manager.getPlayerShard(playerUuid);
+		return Optional.ofNullable(manager.getPlayerShard(playerName));
 	}
 
-	@Nullable
-	public static RemotePlayerManager.RemotePlayer getRemotePlayer(String playerName) {
+	public static Optional<String> getPlayerShard(UUID playerUuid) {
 		RemotePlayerManager manager = RemotePlayerManager.getInstance();
 		if (manager == null) {
-			return null;
+			return Optional.empty();
 		}
-		return manager.getRemotePlayer(playerName);
+		return Optional.ofNullable(manager.getPlayerShard(playerUuid));
 	}
 
-	@Nullable
-	public static RemotePlayerManager.RemotePlayer getRemotePlayer(UUID playerUuid) {
+	public static Optional<RemotePlayerManager.RemotePlayer> getRemotePlayer(String playerName) {
 		RemotePlayerManager manager = RemotePlayerManager.getInstance();
 		if (manager == null) {
-			return null;
+			return Optional.empty();
 		}
-		return manager.getRemotePlayer(playerUuid);
+		return Optional.ofNullable(manager.getRemotePlayer(playerName));
+	}
+
+	public static Optional<RemotePlayerManager.RemotePlayer> getRemotePlayer(UUID playerUuid) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(manager.getRemotePlayer(playerUuid));
+	}
+
+	public static Optional<Boolean> isPlayerVanished(UUID playerUuid) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return Optional.empty();
+		}
+		return Optional.of(manager.isPlayerVisible(playerUuid));
+	}
+
+	public static Optional<Boolean> isPlayerVanished(String playerName) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return Optional.empty();
+		}
+		return Optional.of(manager.isPlayerVisible(playerName));
 	}
 
 	/**

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -2,8 +2,6 @@ package com.playmonumenta.networkrelay;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -102,59 +102,39 @@ public class NetworkRelayAPI {
 	}
 
 	public static Set<String> getOnlinePlayerNames(boolean visibleOnly) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return new HashSet<>();
-		}
-		return manager.getAllOnlinePlayersName(visibleOnly);
+		return RemotePlayerManager.getAllOnlinePlayersName(visibleOnly);
 	}
 
-	public static Optional<String> getPlayerShard(String playerName) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(manager.getPlayerShard(playerName));
+	public static boolean isPlayerOnline(String playerName) {
+		return RemotePlayerManager.isPlayerOnline(playerName);
 	}
 
-	public static Optional<String> getPlayerShard(UUID playerUuid) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(manager.getPlayerShard(playerUuid));
+	public static boolean isPlayerOnline(UUID playerUuid) {
+		return RemotePlayerManager.isPlayerOnline(playerUuid);
 	}
 
-	public static Optional<RemotePlayerManager.RemotePlayer> getRemotePlayer(String playerName) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(manager.getRemotePlayer(playerName));
+	public static String getPlayerShard(String playerName) {
+		return RemotePlayerManager.getPlayerShard(playerName);
 	}
 
-	public static Optional<RemotePlayerManager.RemotePlayer> getRemotePlayer(UUID playerUuid) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(manager.getRemotePlayer(playerUuid));
+	public static String getPlayerShard(UUID playerUuid) {
+		return RemotePlayerManager.getPlayerShard(playerUuid);
 	}
 
-	public static Optional<Boolean> isPlayerVanished(UUID playerUuid) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.of(manager.isPlayerVisible(playerUuid));
+	public static RemotePlayerManager.RemotePlayer getRemotePlayer(String playerName) {
+		return RemotePlayerManager.getRemotePlayer(playerName);
 	}
 
-	public static Optional<Boolean> isPlayerVanished(String playerName) {
-		RemotePlayerManager manager = RemotePlayerManager.getInstance();
-		if (manager == null) {
-			return Optional.empty();
-		}
-		return Optional.of(manager.isPlayerVisible(playerName));
+	public static RemotePlayerManager.RemotePlayer getRemotePlayer(UUID playerUuid) {
+		return RemotePlayerManager.getRemotePlayer(playerUuid);
+	}
+
+	public static boolean isPlayerVanished(UUID playerUuid) {
+		return RemotePlayerManager.isPlayerVisible(playerUuid);
+	}
+
+	public static boolean isPlayerVanished(String playerName) {
+		return RemotePlayerManager.isPlayerVisible(playerName);
 	}
 
 	/**

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -113,18 +113,22 @@ public class NetworkRelayAPI {
 		return RemotePlayerManager.isPlayerOnline(playerUuid);
 	}
 
+	@Nullable
 	public static String getPlayerShard(String playerName) {
 		return RemotePlayerManager.getPlayerShard(playerName);
 	}
 
+	@Nullable
 	public static String getPlayerShard(UUID playerUuid) {
 		return RemotePlayerManager.getPlayerShard(playerUuid);
 	}
 
+	@Nullable
 	public static RemotePlayerManager.RemotePlayer getRemotePlayer(String playerName) {
 		return RemotePlayerManager.getRemotePlayer(playerName);
 	}
 
+	@Nullable
 	public static RemotePlayerManager.RemotePlayer getRemotePlayer(UUID playerUuid) {
 		return RemotePlayerManager.getRemotePlayer(playerUuid);
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -3,6 +3,7 @@ package com.playmonumenta.networkrelay;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.Set;
+import java.util.UUID;
 import org.jetbrains.annotations.Nullable;
 
 public class NetworkRelayAPI {
@@ -96,6 +97,50 @@ public class NetworkRelayAPI {
 
 	public static Set<String> getOnlineShardNames() {
 		return getInstance().getOnlineShardNames();
+	}
+
+	public static String[] getOnlinePlayerNames() {
+			RemotePlayerManager manager = RemotePlayerManager.getInstance();
+			if (manager == null) {
+				return new String[]{};
+			}
+			return manager.getAllOnlinePlayersName();
+	}
+
+	@Nullable
+	public static String getPlayerShard(String playerName) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return null;
+		}
+		return manager.getPlayerShard(playerName);
+	}
+
+	@Nullable
+	public static String getPlayerShard(UUID playerUuid) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return null;
+		}
+		return manager.getPlayerShard(playerUuid);
+	}
+
+	@Nullable
+	public static RemotePlayerManager.RemotePlayer getRemotePlayer(String playerName) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return null;
+		}
+		return manager.getRemotePlayer(playerName);
+	}
+
+	@Nullable
+	public static RemotePlayerManager.RemotePlayer getRemotePlayer(UUID playerUuid) {
+		RemotePlayerManager manager = RemotePlayerManager.getInstance();
+		if (manager == null) {
+			return null;
+		}
+		return manager.getRemotePlayer(playerUuid);
 	}
 
 	/**

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -100,43 +100,43 @@ public class NetworkRelayAPI {
 	}
 
 	public static Set<String> getOnlinePlayerNames(boolean visibleOnly) {
-		return RemotePlayerManager.getAllOnlinePlayersName(visibleOnly);
+		return RemotePlayerAPI.getOnlinePlayerNames(visibleOnly);
 	}
 
 	public static boolean isPlayerOnline(String playerName) {
-		return RemotePlayerManager.isPlayerOnline(playerName);
+		return RemotePlayerAPI.isPlayerOnline(playerName);
 	}
 
 	public static boolean isPlayerOnline(UUID playerUuid) {
-		return RemotePlayerManager.isPlayerOnline(playerUuid);
+		return RemotePlayerAPI.isPlayerOnline(playerUuid);
 	}
 
 	@Nullable
 	public static String getPlayerShard(String playerName) {
-		return RemotePlayerManager.getPlayerShard(playerName);
+		return RemotePlayerAPI.getPlayerShard(playerName);
 	}
 
 	@Nullable
 	public static String getPlayerShard(UUID playerUuid) {
-		return RemotePlayerManager.getPlayerShard(playerUuid);
+		return RemotePlayerAPI.getPlayerShard(playerUuid);
 	}
 
 	@Nullable
-	public static RemotePlayerManager.RemotePlayer getRemotePlayer(String playerName) {
-		return RemotePlayerManager.getRemotePlayer(playerName);
+	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(String playerName) {
+		return RemotePlayerAPI.getRemotePlayer(playerName);
 	}
 
 	@Nullable
-	public static RemotePlayerManager.RemotePlayer getRemotePlayer(UUID playerUuid) {
-		return RemotePlayerManager.getRemotePlayer(playerUuid);
-	}
-
-	public static boolean isPlayerVanished(UUID playerUuid) {
-		return RemotePlayerManager.isPlayerVisible(playerUuid);
+	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
+		return RemotePlayerAPI.getRemotePlayer(playerUuid);
 	}
 
 	public static boolean isPlayerVanished(String playerName) {
-		return RemotePlayerManager.isPlayerVisible(playerName);
+		return RemotePlayerAPI.isPlayerVanished(playerName);
+	}
+
+	public static boolean isPlayerVanished(UUID playerUuid) {
+		return RemotePlayerAPI.isPlayerVanished(playerUuid);
 	}
 
 	/**

--- a/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/NetworkRelayAPI.java
@@ -122,12 +122,12 @@ public class NetworkRelayAPI {
 	}
 
 	@Nullable
-	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(String playerName) {
+	public static RemotePlayerAbstraction getRemotePlayer(String playerName) {
 		return RemotePlayerAPI.getRemotePlayer(playerName);
 	}
 
 	@Nullable
-	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
+	public static RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
 		return RemotePlayerAPI.getRemotePlayer(playerUuid);
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
@@ -1,0 +1,73 @@
+package com.playmonumenta.networkrelay;
+
+import java.util.Set;
+import java.util.UUID;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.jetbrains.annotations.Nullable;
+
+public class RemotePlayerAPI {
+	@MonotonicNonNull
+	private static RemotePlayerManagerAbstraction mManager = null;
+
+	public static void init(RemotePlayerManagerAbstraction manager) {
+		mManager = manager;
+	}
+
+	public static Set<String> getOnlinePlayerNames(boolean visibleOnly) {
+		innerCheckManagerLoaded();
+		return mManager.getAllOnlinePlayersName(visibleOnly);
+	}
+
+	public static boolean isPlayerOnline(String playerName) {
+		innerCheckManagerLoaded();
+		return mManager.isPlayerOnline(playerName);
+	}
+
+	public static boolean isPlayerOnline(UUID playerUuid) {
+		innerCheckManagerLoaded();
+		return mManager.isPlayerOnline(playerUuid);
+	}
+
+	@Nullable
+	public static String getPlayerShard(String playerName) {
+		innerCheckManagerLoaded();
+		return mManager.getPlayerShard(playerName);
+	}
+
+	@Nullable
+	public static String getPlayerShard(UUID playerUuid) {
+		innerCheckManagerLoaded();
+		return mManager.getPlayerShard(playerUuid);
+	}
+
+	@Nullable
+	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(String playerName) {
+		innerCheckManagerLoaded();
+		return mManager.getRemotePlayer(playerName);
+	}
+
+	@Nullable
+	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
+		innerCheckManagerLoaded();
+		return mManager.getRemotePlayer(playerUuid);
+	}
+
+	public static boolean isPlayerVanished(String playerName) {
+		innerCheckManagerLoaded();
+		return mManager.isPlayerVisible(playerName);
+	}
+	public static boolean isPlayerVanished(UUID playerUuid) {
+		innerCheckManagerLoaded();
+		return mManager.isPlayerVisible(playerUuid);
+	}
+
+	public static boolean isManagerLoaded() {
+		return !(mManager == null);
+	}
+
+	private static void innerCheckManagerLoaded() {
+		if (mManager == null) {
+			throw new IllegalStateException("RemotePlayerManager is not loaded");
+		}
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
@@ -56,6 +56,7 @@ public class RemotePlayerAPI {
 		innerCheckManagerLoaded();
 		return mManager.isPlayerVisible(playerName);
 	}
+
 	public static boolean isPlayerVanished(UUID playerUuid) {
 		innerCheckManagerLoaded();
 		return mManager.isPlayerVisible(playerUuid);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAPI.java
@@ -41,13 +41,13 @@ public class RemotePlayerAPI {
 	}
 
 	@Nullable
-	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(String playerName) {
+	public static RemotePlayerAbstraction getRemotePlayer(String playerName) {
 		innerCheckManagerLoaded();
 		return mManager.getRemotePlayer(playerName);
 	}
 
 	@Nullable
-	public static RemotePlayerManagerAbstraction.RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
+	public static RemotePlayerAbstraction getRemotePlayer(UUID playerUuid) {
 		innerCheckManagerLoaded();
 		return mManager.getRemotePlayer(playerUuid);
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAbstraction.java
@@ -38,7 +38,7 @@ public abstract class RemotePlayerAbstraction {
 			case RemotePlayerBungee.SERVER_TYPE:
 				return RemotePlayerBungee.bungeeFrom(remoteData);
 			default:
-				return RemotePlayerGeneric.genericFrom(remoteData);
+				return RemotePlayerGeneric.genericFrom(serverType, remoteData);
 		}
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerAbstraction.java
@@ -1,0 +1,81 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class RemotePlayerAbstraction {
+	protected final UUID mUuid;
+	protected final String mName;
+	protected final boolean mIsOnline;
+	private final ConcurrentMap<String, JsonObject> mPluginData;
+
+	protected RemotePlayerAbstraction(UUID uuid, String name, boolean isOnline) {
+		mUuid = uuid;
+		mName = name;
+		mIsOnline = isOnline;
+		mPluginData = new ConcurrentHashMap<>();
+		mPluginData.putAll(gatherPluginData());
+	}
+
+	protected RemotePlayerAbstraction(UUID uuid, String name, boolean isOnline, JsonObject remoteData) {
+		mUuid = uuid;
+		mName = name;
+		mIsOnline = isOnline;
+		mPluginData = deserializePluginData(remoteData);
+	}
+
+	protected abstract Map<String, JsonObject> gatherPluginData();
+
+	public static RemotePlayerAbstraction from(JsonObject remoteData) {
+		String serverType = remoteData.get("serverType").getAsString();
+		switch (serverType) {
+			case RemotePlayerPaper.SERVER_TYPE:
+				return RemotePlayerPaper.paperFrom(remoteData);
+			case RemotePlayerBungee.SERVER_TYPE:
+				return RemotePlayerBungee.bungeeFrom(remoteData);
+			default:
+				return RemotePlayerGeneric.genericFrom(remoteData);
+		}
+	}
+
+	@Nullable
+	public JsonObject getPluginData(String pluginId) {
+		return mPluginData.get(pluginId);
+	}
+
+	protected ConcurrentMap<String, JsonObject> deserializePluginData(JsonObject remoteData) {
+		ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
+		// "plugins": {"plugin-name": {}}
+		JsonObject pluginData = remoteData.getAsJsonObject("plugins");
+		for (String key : pluginData.keySet()) {
+			pluginDataMap.put(key, pluginData.getAsJsonObject(key));
+		}
+		return pluginDataMap;
+	}
+
+	protected JsonObject serializePluginData() {
+		JsonObject pluginData = new JsonObject();
+		for (Map.Entry<String, JsonObject> entry : mPluginData.entrySet()) {
+			pluginData.add(entry.getKey(), entry.getValue());
+		}
+		return pluginData;
+	}
+
+	public abstract String getServerType();
+
+	public UUID getUuid() {
+		return mUuid;
+	}
+
+	public String getName() {
+		return mName;
+	}
+
+	public boolean isOnline() {
+		return mIsOnline;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerBungee.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerBungee.java
@@ -1,0 +1,56 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import com.playmonumenta.networkrelay.util.MMLog;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class RemotePlayerBungee extends RemotePlayerAbstraction {
+	protected static final String SERVER_TYPE = "proxy";
+	private final String mProxy;
+	private final String mShard;
+
+	protected RemotePlayerBungee(UUID uuid, String name, boolean isOnline, String shard, String proxy) {
+		super(uuid, name, isOnline);
+		mProxy = proxy;
+		mShard = shard;
+
+		MMLog.fine("Created RemotePlayerBungee for " + mName + " from " + mProxy + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	protected RemotePlayerBungee(UUID uuid, String name, boolean isOnline, String shard, String proxy, JsonObject remoteData) {
+		super(uuid, name, isOnline, remoteData);
+		mProxy = proxy;
+		mShard = shard;
+
+		MMLog.fine("Received RemotePlayerBungee for " + mName + " from " + mProxy + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	@Override
+	protected Map<String, JsonObject> gatherPluginData() {
+		return new HashMap<>();
+	}
+
+	protected static RemotePlayerBungee bungeeFrom(JsonObject remoteData) {
+		UUID uuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
+		String name = remoteData.get("playerName").getAsString();
+		boolean isOnline = remoteData.get("isOnline").getAsBoolean();
+		String proxy = remoteData.get("proxy").getAsString();
+		String shard = remoteData.get("shard").getAsString();
+		return new RemotePlayerBungee(uuid, name, isOnline, shard, proxy, remoteData);
+	}
+
+	@Override
+	public String getServerType() {
+		return SERVER_TYPE;
+	}
+
+	public String getProxy() {
+		return mProxy;
+	}
+
+	public String getShard() {
+		return mShard;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerGeneric.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerGeneric.java
@@ -1,0 +1,50 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import com.playmonumenta.networkrelay.util.MMLog;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class RemotePlayerGeneric extends RemotePlayerAbstraction {
+	protected final String mServerType;
+	protected final String mShard;
+
+	protected RemotePlayerGeneric(UUID uuid, String name, boolean isOnline, String serverType, String shard) {
+		super(uuid, name, isOnline);
+		mServerType = serverType;
+		mShard = shard;
+
+		MMLog.fine("Created RemotePlayerBungee for " + mName + " from " + mShard + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	protected RemotePlayerGeneric(UUID uuid, String name, boolean isOnline, String serverType, String shard, JsonObject remoteData) {
+		super(uuid, name, isOnline, remoteData);
+		mServerType = serverType;
+		mShard = shard;
+
+		MMLog.fine("Received RemotePlayerBungee for " + mName + " from " + mShard + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	@Override
+	protected Map<String, JsonObject> gatherPluginData() {
+		return new HashMap<>();
+	}
+
+	protected static RemotePlayerGeneric genericFrom(JsonObject remoteData) {
+		UUID uuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
+		String name = remoteData.get("playerName").getAsString();
+		boolean isOnline = remoteData.get("isOnline").getAsBoolean();
+		String shard = remoteData.get("shard").getAsString();
+		return new RemotePlayerGeneric(uuid, name, isOnline, shard, remoteData);
+	}
+
+	@Override
+	public String getServerType() {
+		return mServerType;
+	}
+
+	public String getShard() {
+		return mShard;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerGeneric.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerGeneric.java
@@ -31,12 +31,12 @@ public class RemotePlayerGeneric extends RemotePlayerAbstraction {
 		return new HashMap<>();
 	}
 
-	protected static RemotePlayerGeneric genericFrom(JsonObject remoteData) {
+	protected static RemotePlayerGeneric genericFrom(String serverType, JsonObject remoteData) {
 		UUID uuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
 		String name = remoteData.get("playerName").getAsString();
 		boolean isOnline = remoteData.get("isOnline").getAsBoolean();
 		String shard = remoteData.get("shard").getAsString();
-		return new RemotePlayerGeneric(uuid, name, isOnline, shard, remoteData);
+		return new RemotePlayerGeneric(uuid, name, isOnline, serverType, shard, remoteData);
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
@@ -6,10 +6,10 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerLoadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
+	public final RemotePlayerManagerPaper.RemotePlayer mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerLoadedEvent(RemotePlayerManager.RemotePlayer remotePlayer) {
+	public RemotePlayerLoadedEvent(RemotePlayerManagerPaper.RemotePlayer remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
@@ -2,20 +2,20 @@ package com.playmonumenta.networkrelay;
 
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class RemotePlayerLoadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
 	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
 	public final String mShard;
-	public RemotePlayerLoadedEvent(@NotNull RemotePlayerManager.RemotePlayer remotePlayer) {
+
+	public RemotePlayerLoadedEvent(RemotePlayerManager.RemotePlayer remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}
 
 	@Override
-	public @NotNull HandlerList getHandlers() {
+	public HandlerList getHandlers() {
 		return handlers;
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
@@ -1,0 +1,25 @@
+package com.playmonumenta.networkrelay;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class RemotePlayerLoadedEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+
+	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
+	public final String mShard;
+	public RemotePlayerLoadedEvent(@NotNull RemotePlayerManager.RemotePlayer remotePlayer) {
+		mRemotePlayer = remotePlayer;
+		mShard = remotePlayer.mShard;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
@@ -6,12 +6,12 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerLoadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManagerPaper.RemotePlayerPaper mRemotePlayer;
+	public final RemotePlayerPaper mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerLoadedEvent(RemotePlayerManagerPaper.RemotePlayerPaper remotePlayer) {
+	public RemotePlayerLoadedEvent(RemotePlayerPaper remotePlayer) {
 		mRemotePlayer = remotePlayer;
-		mShard = remotePlayer.mShard;
+		mShard = remotePlayer.getShard();
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerLoadedEvent.java
@@ -6,10 +6,10 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerLoadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManagerPaper.RemotePlayer mRemotePlayer;
+	public final RemotePlayerManagerPaper.RemotePlayerPaper mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerLoadedEvent(RemotePlayerManagerPaper.RemotePlayer remotePlayer) {
+	public RemotePlayerLoadedEvent(RemotePlayerManagerPaper.RemotePlayerPaper remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
@@ -22,13 +22,88 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class RemotePlayerManager implements Listener {
+	public static class RemotePlayer {
+		public final UUID mUuid;
+		public final String mName;
+		public final String mShard;
+		public final boolean mIsHidden;
+		public final boolean mIsOnline;
+		private final ConcurrentMap<String, JsonObject> mPluginData;
+
+		public RemotePlayer(Player player, boolean isOnline) {
+			mUuid = player.getUniqueId();
+			mName = player.getName();
+			RemotePlayerManager manager = RemotePlayerManager.getInstance();
+			mShard = (manager != null && manager.getShardName() != null) ? manager.getShardName() : NetworkRelayAPI.getShardName();
+			mIsHidden = (manager != null && !manager.isLocalPlayerVisible(player));
+			mIsOnline = isOnline;
+			mPluginData = new ConcurrentHashMap<>();
+		}
+
+		public RemotePlayer(JsonObject remoteData) {
+			mUuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
+			mName = remoteData.get("playerName").getAsString();
+			mIsHidden = remoteData.get("isHidden").getAsBoolean();
+			mIsOnline = remoteData.get("isOnline").getAsBoolean();
+			mShard = remoteData.get("shard").getAsString();
+			mPluginData = serializePluginData(remoteData);
+		}
+
+		@Nullable
+		public JsonObject getPluginData(String pluginId) {
+			return mPluginData.get(pluginId);
+		}
+
+		private ConcurrentMap<String, JsonObject> serializePluginData(JsonObject remoteData) {
+			ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
+			//"plugins": {"plugin-name": {}}
+			JsonObject pluginData = remoteData.getAsJsonObject("plugins");
+			for (String key : pluginData.keySet()) {
+				pluginDataMap.put(key, pluginData.getAsJsonObject(key));
+			}
+			return pluginDataMap;
+		}
+
+		private JsonObject deserializePluginData() {
+			JsonObject pluginData = new JsonObject();
+			for (Map.Entry<String, JsonObject> entry : mPluginData.entrySet()) {
+				pluginData.add(entry.getKey(), entry.getValue());
+			}
+			return pluginData;
+		}
+
+		public void broadcast() {
+			JsonObject remotePlayerData = new JsonObject();
+			remotePlayerData.addProperty("playerUuid", mUuid.toString());
+			remotePlayerData.addProperty("playerName", mName);
+			remotePlayerData.addProperty("isHidden", mIsHidden);
+			remotePlayerData.addProperty("isOnline", mIsOnline);
+			remotePlayerData.addProperty("shard", mShard);
+
+			//Gather Plugin data
+			GatherRemotePlayerDataEvent event = new GatherRemotePlayerDataEvent();
+			Bukkit.getPluginManager().callEvent(event);
+			mPluginData.clear();
+			mPluginData.putAll(event.getPluginData());
+
+			remotePlayerData.add("plugins", deserializePluginData());
+
+			try {
+				NetworkRelayAPI.sendBroadcastMessage(RemotePlayerManager.REMOTE_PLAYER_UPDATE_CHANNEL, remotePlayerData);
+			} catch (Exception e) {
+				RemotePlayerManager manager = RemotePlayerManager.getInstance();
+				if (manager != null) {
+					manager.mPlugin.getLogger().warning("Failed to broadcast to channel " + REMOTE_PLAYER_UPDATE_CHANNEL + " reason: " + e.getMessage());
+				}
+			}
+		}
+	}
+
 	public static final String REMOTE_PLAYER_CHANNEL_BASE = "monumenta.redissync.remote_player";
-	public static final String REMOTE_PLAYER_UPDATE_CHANNEL = REMOTE_PLAYER_CHANNEL_BASE + ".update";
 	public static final String REMOTE_PLAYER_REFRESH_CHANNEL = REMOTE_PLAYER_CHANNEL_BASE + ".refresh";
+	public static final String REMOTE_PLAYER_UPDATE_CHANNEL = REMOTE_PLAYER_CHANNEL_BASE + ".update";
 
-	@MonotonicNonNull
-	private static RemotePlayerManager INSTANCE = null;
-
+	private static @MonotonicNonNull RemotePlayerManager INSTANCE = null;
 	private static final Map<String, Map<String, RemotePlayer>> mRemotePlayerShardMapped = new ConcurrentSkipListMap<>();
 	private static final Map<UUID, RemotePlayer> mRemotePlayersByUuid = new ConcurrentSkipListMap<>();
 	private static final Map<String, RemotePlayer> mRemotePlayersByName = new ConcurrentSkipListMap<>();
@@ -37,6 +112,7 @@ public class RemotePlayerManager implements Listener {
 	private final NetworkRelay mPlugin;
 
 	protected RemotePlayerManager(NetworkRelay plugin) {
+		INSTANCE = this;
 		mPlugin = plugin;
 		String lShard = getShardName();
 		try {
@@ -55,8 +131,6 @@ public class RemotePlayerManager implements Listener {
 		} catch (Exception e) {
 			mPlugin.getLogger().warning("Failed to broadcast to channel " + REMOTE_PLAYER_REFRESH_CHANNEL);
 		}
-
-		INSTANCE = this;
 	}
 
 	@Nullable
@@ -65,6 +139,25 @@ public class RemotePlayerManager implements Listener {
 			return null;
 		}
 		return INSTANCE;
+	}
+
+	@Nullable
+	protected String getShardName() {
+		@Nullable String shardName = null;
+		try {
+			shardName = NetworkRelayAPI.getShardName();
+		} catch (Exception e) {
+			mPlugin.getLogger().severe("Failed to retrieve shard name");
+		}
+		return shardName;
+	}
+
+	public static boolean isPlayerOnline(UUID playerUuid) {
+		return mRemotePlayersByUuid.containsKey(playerUuid);
+	}
+
+	public boolean isPlayerOnline(String playerName) {
+		return mRemotePlayersByName.containsKey(playerName);
 	}
 
 	protected Set<String> getAllOnlinePlayersName(boolean visibleOnly) {
@@ -112,6 +205,30 @@ public class RemotePlayerManager implements Listener {
 		return isPlayerVisible(playerUuid);
 	}
 
+	protected @Nullable String getPlayerName(@Nullable UUID playerUuid) {
+		if (playerUuid == null) {
+			return null;
+		}
+
+		@Nullable RemotePlayer remotePlayer = mRemotePlayersByUuid.get(playerUuid);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mName;
+	}
+
+	protected @Nullable UUID getPlayerUuid(@Nullable String playerName) {
+		if (playerName == null) {
+			return null;
+		}
+
+		@Nullable RemotePlayer remotePlayer = mRemotePlayersByName.get(playerName);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mUuid;
+	}
+
 	@Nullable
 	protected String getPlayerShard(@NotNull String username) {
 		@Nullable RemotePlayer remotePlayer = getRemotePlayer(username);
@@ -143,41 +260,6 @@ public class RemotePlayerManager implements Listener {
 
 		@Nullable RemotePlayer remotePlayer = mRemotePlayersByUuid.get(playerUuid);
 		return remotePlayer;
-	}
-
-	@Nullable
-	protected String getShardName() {
-		@Nullable String shardName = null;
-		try {
-			shardName = NetworkRelayAPI.getShardName();
-		} catch (Exception e) {
-			mPlugin.getLogger().severe("Failed to retrieve shard name");
-		}
-		return shardName;
-	}
-
-	protected @Nullable String getPlayerName(@Nullable UUID playerUuid) {
-		if (playerUuid == null) {
-			return null;
-		}
-
-		@Nullable RemotePlayer remotePlayer = mRemotePlayersByUuid.get(playerUuid);
-		if (remotePlayer == null) {
-			return null;
-		}
-		return remotePlayer.mName;
-	}
-
-	protected @Nullable UUID getPlayerUuid(@Nullable String playerName) {
-		if (playerName == null) {
-			return null;
-		}
-
-		@Nullable RemotePlayer remotePlayer = mRemotePlayersByName.get(playerName);
-		if (remotePlayer == null) {
-			return null;
-		}
-		return remotePlayer.mUuid;
 	}
 
 	protected void refreshLocalPlayers() {
@@ -315,84 +397,6 @@ public class RemotePlayerManager implements Listener {
 			}
 			default: {
 				break;
-			}
-		}
-	}
-
-	public static class RemotePlayer {
-		public final UUID mUuid;
-		public final String mName;
-		public final String mShard;
-		public final boolean mIsHidden;
-		public final boolean mIsOnline;
-		private final ConcurrentMap<String, JsonObject> mPluginData;
-
-		public RemotePlayer(Player player, boolean isOnline) {
-			mUuid = player.getUniqueId();
-			mName = player.getName();
-			RemotePlayerManager manager = RemotePlayerManager.getInstance();
-			mShard = (manager != null && manager.getShardName() != null) ? manager.getShardName() : NetworkRelayAPI.getShardName();
-			mIsHidden = (manager != null && !manager.isLocalPlayerVisible(player));
-			mIsOnline = isOnline;
-			mPluginData = new ConcurrentHashMap<>();
-		}
-
-		public RemotePlayer(JsonObject remoteData) {
-			mUuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
-			mName = remoteData.get("playerName").getAsString();
-			mIsHidden = remoteData.get("isHidden").getAsBoolean();
-			mIsOnline = remoteData.get("isOnline").getAsBoolean();
-			mShard = remoteData.get("shard").getAsString();
-			mPluginData = serializePluginData(remoteData);
-		}
-
-		@Nullable
-		public JsonObject getPluginData(String pluginId) {
-			return mPluginData.get(pluginId);
-		}
-
-		private ConcurrentMap<String, JsonObject> serializePluginData(JsonObject remoteData) {
-			ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
-			//"plugins": {"plugin-name": {}}
-			JsonObject pluginData = remoteData.getAsJsonObject("plugins");
-			for (String key : pluginData.keySet()) {
-				pluginDataMap.put(key, pluginData.getAsJsonObject(key));
-			}
-			return pluginDataMap;
-		}
-
-		private JsonObject deserializePluginData() {
-			JsonObject pluginData = new JsonObject();
-			for (Map.Entry<String, JsonObject> entry : mPluginData.entrySet()) {
-				pluginData.add(entry.getKey(), entry.getValue());
-			}
-			return pluginData;
-		}
-
-		public void broadcast() {
-			JsonObject remotePlayerData = new JsonObject();
-			remotePlayerData.addProperty("playerUuid", mUuid.toString());
-			remotePlayerData.addProperty("playerName", mName);
-			remotePlayerData.addProperty("isHidden", mIsHidden);
-			remotePlayerData.addProperty("isOnline", mIsOnline);
-			remotePlayerData.addProperty("shard", mShard);
-
-			//Gather Plugin data
-			GatherRemotePlayerDataEvent event = new GatherRemotePlayerDataEvent();
-			Bukkit.getPluginManager().callEvent(event);
-			mPluginData.clear();
-			mPluginData.putAll(event.getPluginData());
-
-			remotePlayerData.add("plugins", deserializePluginData());
-
-			try {
-				NetworkRelayAPI.sendBroadcastMessage(RemotePlayerManager.REMOTE_PLAYER_UPDATE_CHANNEL,
-					remotePlayerData);
-			} catch (Exception e) {
-				RemotePlayerManager manager = RemotePlayerManager.getInstance();
-				if (manager != null) {
-					manager.mPlugin.getLogger().warning("Failed to broadcast to channel " + REMOTE_PLAYER_UPDATE_CHANNEL + " reason: " + e.getMessage());
-				}
 			}
 		}
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
@@ -33,9 +33,8 @@ public class RemotePlayerManager implements Listener {
 		public RemotePlayer(Player player, boolean isOnline) {
 			mUuid = player.getUniqueId();
 			mName = player.getName();
-			RemotePlayerManager manager = RemotePlayerManager.getInstance();
-			mShard = (manager != null && manager.getShardName() != null) ? manager.getShardName() : NetworkRelayAPI.getShardName();
-			mIsHidden = (manager != null && !manager.isLocalPlayerVisible(player));
+			mShard = getShardName() != null ? getShardName() : NetworkRelayAPI.getShardName();
+			mIsHidden = !isLocalPlayerVisible(player);
 			mIsOnline = isOnline;
 			mPluginData = new ConcurrentHashMap<>();
 		}
@@ -109,7 +108,7 @@ public class RemotePlayerManager implements Listener {
 	private static final Map<String, RemotePlayer> mRemotePlayersByName = new ConcurrentSkipListMap<>();
 	private static final Set<UUID> mVisiblePlayers = new ConcurrentSkipListSet<>();
 
-	protected RemotePlayerManager(NetworkRelay plugin) {
+	protected RemotePlayerManager() {
 		INSTANCE = this;
 		String lShard = getShardName();
 		try {

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
@@ -399,7 +399,7 @@ public class RemotePlayerManager implements Listener {
 		Player player = event.getPlayer();
 		RemotePlayer oldRemotePlayer = mRemotePlayersByUuid.get(player.getUniqueId());
 		if (oldRemotePlayer != null && !oldRemotePlayer.mShard.equals(getShardName())) {
-			MMLog.fine("Refusing to unregister player: they are on another shard");
+			MMLog.fine("Refusing to unregister player " + player.getName() + ": they are on another shard");
 			return;
 		}
 		RemotePlayer remotePlayer = new RemotePlayer(player, false);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
@@ -138,7 +138,7 @@ public class RemotePlayerManager implements Listener {
 		}
 	}
 
-	public static RemotePlayerManager getInstance() {
+	protected static RemotePlayerManager getInstance() {
 		if (INSTANCE == null) {
 			INSTANCE = new RemotePlayerManager();
 		}
@@ -158,22 +158,22 @@ public class RemotePlayerManager implements Listener {
 		return shardName;
 	}
 
-	public static Set<String> getAllOnlinePlayersName(boolean visibleOnly) {
+	protected static Set<String> getAllOnlinePlayersName(boolean visibleOnly) {
 		if (visibleOnly) {
 			return getVisiblePlayerNames();
 		}
 		return new HashSet<>(mRemotePlayersByName.keySet());
 	}
 
-	public static boolean isPlayerOnline(UUID playerUuid) {
+	protected static boolean isPlayerOnline(UUID playerUuid) {
 		return mRemotePlayersByUuid.containsKey(playerUuid);
 	}
 
-	public static boolean isPlayerOnline(String playerName) {
+	protected static boolean isPlayerOnline(String playerName) {
 		return mRemotePlayersByName.containsKey(playerName);
 	}
 
-	public static Set<String> getVisiblePlayerNames() {
+	protected static Set<String> getVisiblePlayerNames() {
 		Set<String> results = new ConcurrentSkipListSet<>();
 		for (UUID playerUuid : mVisiblePlayers) {
 			results.add(getPlayerName(playerUuid));
@@ -190,7 +190,7 @@ public class RemotePlayerManager implements Listener {
 		return true;
 	}
 
-	public static boolean isPlayerVisible(Player player) {
+	protected static boolean isPlayerVisible(Player player) {
 		boolean cachedResult = isPlayerVisible(player.getUniqueId());
 		boolean currentResult = internalPlayerVisibleTest(player);
 		if (cachedResult ^ currentResult) {
@@ -199,11 +199,11 @@ public class RemotePlayerManager implements Listener {
 		return currentResult;
 	}
 
-	public static boolean isPlayerVisible(UUID playerUuid) {
+	protected static boolean isPlayerVisible(UUID playerUuid) {
 		return mVisiblePlayers.contains(playerUuid);
 	}
 
-	public static boolean isPlayerVisible(String playerName) {
+	protected static boolean isPlayerVisible(String playerName) {
 		@Nullable UUID playerUuid = getPlayerUuid(playerName);
 		if (playerUuid == null) {
 			return false;
@@ -211,7 +211,7 @@ public class RemotePlayerManager implements Listener {
 		return isPlayerVisible(playerUuid);
 	}
 
-	public static @Nullable String getPlayerName(@Nullable UUID playerUuid) {
+	protected static @Nullable String getPlayerName(@Nullable UUID playerUuid) {
 		if (playerUuid == null) {
 			return null;
 		}
@@ -223,7 +223,7 @@ public class RemotePlayerManager implements Listener {
 		return remotePlayer.mName;
 	}
 
-	public static @Nullable UUID getPlayerUuid(@Nullable String playerName) {
+	protected static @Nullable UUID getPlayerUuid(@Nullable String playerName) {
 		if (playerName == null) {
 			return null;
 		}
@@ -236,7 +236,7 @@ public class RemotePlayerManager implements Listener {
 	}
 
 	@Nullable
-	public static String getPlayerShard(@NotNull String username) {
+	protected static String getPlayerShard(@NotNull String username) {
 		@Nullable RemotePlayer remotePlayer = getRemotePlayer(username);
 		if (remotePlayer == null) {
 			return null;
@@ -245,7 +245,7 @@ public class RemotePlayerManager implements Listener {
 	}
 
 	@Nullable
-	public static String getPlayerShard(@NotNull UUID playerUuid) {
+	protected static String getPlayerShard(@NotNull UUID playerUuid) {
 		@Nullable RemotePlayer remotePlayer = getRemotePlayer(playerUuid);
 		if (remotePlayer == null) {
 			return null;
@@ -254,12 +254,12 @@ public class RemotePlayerManager implements Listener {
 	}
 
 	@Nullable
-	public static RemotePlayer getRemotePlayer(@NotNull String username) {
+	protected static RemotePlayer getRemotePlayer(@NotNull String username) {
 		return mRemotePlayersByName.get(username);
 	}
 
 	@Nullable
-	public static RemotePlayer getRemotePlayer(@Nullable UUID playerUuid) {
+	protected static RemotePlayer getRemotePlayer(@Nullable UUID playerUuid) {
 		if (playerUuid == null) {
 			return null;
 		}
@@ -268,14 +268,14 @@ public class RemotePlayerManager implements Listener {
 		return remotePlayer;
 	}
 
-	public static void refreshLocalPlayers() {
+	protected static void refreshLocalPlayers() {
 		for (Player player : Bukkit.getOnlinePlayers()) {
 			refreshLocalPlayer(player);
 		}
 	}
 
 	// Run this on local players whenever their information is out of date
-	public static void refreshLocalPlayer(Player player) {
+	protected static void refreshLocalPlayer(Player player) {
 		MMLog.fine("Refreshing local player " + player.getName());
 		RemotePlayer remotePlayer = new RemotePlayer(player, true);
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManager.java
@@ -1,0 +1,347 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class RemotePlayerManager implements Listener {
+	public static final String REMOTE_PLAYER_CHANNEL_BASE = "monumenta.redissync.remote_player";
+	public static final String REMOTE_PLAYER_UPDATE_CHANNEL = REMOTE_PLAYER_CHANNEL_BASE + ".update";
+	public static final String REMOTE_PLAYER_REFRESH_CHANNEL = REMOTE_PLAYER_CHANNEL_BASE + ".refresh";
+
+	@MonotonicNonNull
+	private static RemotePlayerManager INSTANCE = null;
+
+	private static final Map<String, Map<String, RemotePlayer>> mRemotePlayerShardMapped = new ConcurrentSkipListMap<>();
+	private static final Map<UUID, RemotePlayer> mRemotePlayersByUuid = new ConcurrentSkipListMap<>();
+	private static final Map<String, RemotePlayer> mRemotePlayersByName = new ConcurrentSkipListMap<>();
+
+
+	private final NetworkRelay mPlugin;
+	protected RemotePlayerManager(NetworkRelay plugin) {
+        mPlugin = plugin;
+		String lShard = getShardName();
+		try {
+			for (String shard: NetworkRelayAPI.getOnlineShardNames()) {
+				if (shard.equals(lShard)) {
+					continue;
+				}
+				mRemotePlayerShardMapped.put(shard, new ConcurrentSkipListMap<>());
+			}
+		} catch (Exception ex) {
+			mPlugin.getLogger().warning("Failed to get load shards");
+		}
+
+		try {
+			NetworkRelayAPI.sendBroadcastMessage(REMOTE_PLAYER_REFRESH_CHANNEL, new JsonObject());
+		} catch (Exception e) {
+			mPlugin.getLogger().warning("Failed to broadcast to channel " + REMOTE_PLAYER_REFRESH_CHANNEL);
+        }
+
+		INSTANCE = this;
+    }
+
+	@Nullable
+	protected static RemotePlayerManager getInstance() {
+		if (INSTANCE == null) {
+			return null;
+		}
+		return INSTANCE;
+	}
+
+	protected String[] getAllOnlinePlayersName() {
+		return mRemotePlayersByName.keySet().toArray(new String[0]);
+	}
+
+	@Nullable
+	protected String getPlayerShard(@NotNull String username) {
+		@Nullable RemotePlayer remotePlayer = getRemotePlayer(username);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mShard;
+	}
+
+	@Nullable
+	protected String getPlayerShard(@NotNull UUID playerUuid) {
+		@Nullable RemotePlayer remotePlayer = getRemotePlayer(playerUuid);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mShard;
+	}
+
+	@Nullable
+	protected RemotePlayer getRemotePlayer(@NotNull String username) {
+		return getRemotePlayer(getPlayerUuid(username));
+	}
+
+	@Nullable
+	protected RemotePlayer getRemotePlayer(@Nullable UUID playerUuid) {
+		if (playerUuid == null) {
+			return null;
+		}
+
+		@Nullable RemotePlayer remotePlayer = mRemotePlayersByUuid.get(playerUuid);
+		return remotePlayer;
+	}
+
+	@Nullable
+	protected String getShardName() {
+		@Nullable String shardName = null;
+		try {
+			shardName = NetworkRelayAPI.getShardName();
+		} catch (Exception e) {
+			mPlugin.getLogger().severe("Failed to retrieve shard name");
+		}
+		return shardName;
+	}
+
+	protected @Nullable String getPlayerName(@Nullable UUID playerUuid) {
+		if (playerUuid == null) {
+			return null;
+		}
+
+ 		@Nullable RemotePlayer remotePlayer = mRemotePlayersByUuid.get(playerUuid);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mName;
+	}
+
+	protected @Nullable UUID getPlayerUuid(@Nullable String playerName) {
+		if (playerName == null) {
+			return null;
+		}
+
+		@Nullable RemotePlayer remotePlayer = mRemotePlayersByName.get(playerName);
+		if (remotePlayer == null) {
+			return null;
+		}
+		return remotePlayer.mUuid;
+	}
+
+	protected void refreshLocalPlayers() {
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			refreshLocalPlayer(player);
+		}
+	}
+
+	protected void refreshLocalPlayer(Player player) {
+		mPlugin.getLogger().fine("Refreshing local player");
+		RemotePlayer remotePlayer = new RemotePlayer(player, true);
+
+		unregisterPlayer(remotePlayer.mUuid);
+		mPlugin.getLogger().fine("Registering local player");
+		mRemotePlayersByUuid.put(remotePlayer.mUuid, remotePlayer);
+		mRemotePlayersByName.put(remotePlayer.mName, remotePlayer);
+		remotePlayer.broadcast();
+	}
+
+	private void unregisterPlayer(UUID playerUuid) {
+		@Nullable RemotePlayer lastPlayerState = mRemotePlayersByUuid.get(playerUuid);
+		if (lastPlayerState != null) {
+			mPlugin.getLogger().fine("Unregistering local player");
+			String lastLoc = lastPlayerState.mShard;
+			@Nullable Map<String, RemotePlayer> lastShardRemotePlayers = mRemotePlayerShardMapped.get(lastLoc);
+			if (lastShardRemotePlayers != null) {
+				lastShardRemotePlayers.remove(lastPlayerState.mName);
+			}
+			mRemotePlayersByUuid.remove(playerUuid);
+			mRemotePlayersByName.remove(lastPlayerState.mName);
+
+			RemotePlayerUnloadedEvent event = new RemotePlayerUnloadedEvent(lastPlayerState);
+			Bukkit.getServer().getPluginManager().callEvent(event);
+		}
+	}
+
+	private void remotePlayerChange(JsonObject data) {
+		RemotePlayer remotePlayer;
+		try {
+			remotePlayer = new RemotePlayer(data);
+		} catch (Exception ex) {
+			mPlugin.getLogger().warning("Received invalid RemotePlayer");
+			return;
+		}
+
+		unregisterPlayer(remotePlayer.mUuid);
+		if (remotePlayer.mIsOnline) {
+			@Nullable Map<String, RemotePlayer> shardRemotePlayers = mRemotePlayerShardMapped.get(remotePlayer.mShard);
+			if (shardRemotePlayers != null) {
+				shardRemotePlayers.put(remotePlayer.mName, remotePlayer);
+			}
+			mPlugin.getLogger().fine("Registering local player from remote data");
+			mRemotePlayersByUuid.put(remotePlayer.mUuid, remotePlayer);
+			mRemotePlayersByName.put(remotePlayer.mName, remotePlayer);
+
+			RemotePlayerLoadedEvent remotePLE = new RemotePlayerLoadedEvent(remotePlayer);
+			Bukkit.getServer().getPluginManager().callEvent(remotePLE);
+		} else if (!Objects.equals(getShardName(), remotePlayer.mName)) {
+			mPlugin.getLogger().fine("Detected race condition, triggering refresh on " + remotePlayer.mName);
+			@Nullable Player localPlayer = Bukkit.getPlayer(remotePlayer.mUuid);
+			if (localPlayer != null) {
+				refreshLocalPlayer(localPlayer);
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void destOnlineEvent(DestOnlineEvent event) {
+		String remoteShardName = event.getDest();
+		if (Objects.equals(getShardName(), remoteShardName)) {
+			return;
+		}
+		mPlugin.getLogger().fine("Registering remote shard");
+		mRemotePlayerShardMapped.put(remoteShardName, new ConcurrentSkipListMap<>());
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void destOfflineEvent(DestOfflineEvent event) {
+		String remoteShardName = event.getDest();
+		@Nullable Map<String, RemotePlayer> remotePlayers = mRemotePlayerShardMapped.get(remoteShardName);
+		if (remotePlayers == null) {
+			return;
+		}
+
+		mPlugin.getLogger().fine("Unregistering remote shard");
+		Map<String, RemotePlayer> remotePlayerCopy = new ConcurrentSkipListMap<>(remotePlayers);
+		for (Map.Entry<String, RemotePlayer> playerEntry: remotePlayerCopy.entrySet()) {
+			RemotePlayer remotePlayer = playerEntry.getValue();
+			unregisterPlayer(remotePlayer.mUuid);
+		}
+		mRemotePlayerShardMapped.remove(remoteShardName);
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void playerJoinEvent(PlayerJoinEvent event) {
+		Player player = event.getPlayer();
+		refreshLocalPlayer(player);
+
+		RemotePlayer remotePlayer = getRemotePlayer(player.getUniqueId());
+		if (remotePlayer != null) {
+			RemotePlayerLoadedEvent remotePLE = new RemotePlayerLoadedEvent(remotePlayer);
+			Bukkit.getServer().getPluginManager().callEvent(remotePLE);
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void playerQuitEvent(PlayerQuitEvent event) {
+		Player player = event.getPlayer();
+		RemotePlayer remotePlayer = new RemotePlayer(player, false);
+		unregisterPlayer(remotePlayer.mUuid);
+		remotePlayer.broadcast();
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void networkRelayMessageEvent(NetworkRelayMessageEvent event) {
+		switch(event.getChannel()) {
+			case REMOTE_PLAYER_UPDATE_CHANNEL: {
+				@Nullable JsonObject data = event.getData();
+				if (data == null) {
+					mPlugin.getLogger().severe("Got " + REMOTE_PLAYER_UPDATE_CHANNEL + " channel with null data");
+					return;
+				}
+				remotePlayerChange(data);
+				break;
+			}
+			case REMOTE_PLAYER_REFRESH_CHANNEL: {
+				refreshLocalPlayers();
+				break;
+			}
+			default: {
+				break;
+			}
+		}
+	}
+
+	public static class RemotePlayer {
+		public final UUID mUuid;
+		public final String mName;
+		public final String mShard;
+		public final boolean mIsOnline;
+		private final ConcurrentMap<String, JsonObject> mPluginData;
+
+		public RemotePlayer(Player player, boolean isOnline) {
+			mUuid = player.getUniqueId();
+			mName = player.getName();
+			RemotePlayerManager manager = RemotePlayerManager.getInstance();
+			mShard = (manager != null && manager.getShardName() != null) ? manager.getShardName() : NetworkRelayAPI.getShardName();
+			mIsOnline = isOnline;
+			mPluginData = new ConcurrentHashMap<>();
+		}
+
+		public RemotePlayer(JsonObject remoteData) {
+			mUuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
+			mName = remoteData.get("playerName").getAsString();
+			mIsOnline = remoteData.get("isOnline").getAsBoolean();
+			mShard = remoteData.get("shard").getAsString();
+			mPluginData = serializePluginData(remoteData);
+		}
+
+		@Nullable
+		public JsonObject getPluginData(String pluginId) {
+			if (mPluginData.containsKey(pluginId)) {
+				return mPluginData.get(pluginId);
+			}
+			return null;
+		}
+
+		private ConcurrentMap<String, JsonObject> serializePluginData(JsonObject remoteData) {
+			ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
+			//"plugins": {"plugin-name": {}}
+			JsonObject pluginData = remoteData.getAsJsonObject("plugins");
+			for (String key: pluginData.keySet()) {
+				pluginDataMap.put(key, pluginData.getAsJsonObject(key));
+			}
+			return pluginDataMap;
+		}
+
+		private JsonObject deserializePluginData() {
+			JsonObject pluginData = new JsonObject();
+			for (Map.Entry<String, JsonObject> entry: mPluginData.entrySet()) {
+				pluginData.add(entry.getKey(), entry.getValue());
+			}
+			return pluginData;
+		}
+
+		public void broadcast() {
+			JsonObject remotePlayerData = new JsonObject();
+			remotePlayerData.addProperty("playerUuid", mUuid.toString());
+			remotePlayerData.addProperty("playerName", mName);
+			remotePlayerData.addProperty("isOnline", mIsOnline);
+			remotePlayerData.addProperty("shard", mShard);
+
+			//Gather Plugin data
+			GatherRemotePlayerDataEvent event = new GatherRemotePlayerDataEvent();
+			Bukkit.getPluginManager().callEvent(event);
+			mPluginData.clear();
+			mPluginData.putAll(event.getPluginData());
+
+			remotePlayerData.add("plugins", deserializePluginData());
+
+			try {
+				NetworkRelayAPI.sendBroadcastMessage(RemotePlayerManager.REMOTE_PLAYER_UPDATE_CHANNEL,
+					remotePlayerData);
+			} catch (Exception e) {
+				RemotePlayerManager manager = RemotePlayerManager.getInstance();
+				if (manager != null) {
+					manager.mPlugin.getLogger().warning("Failed to broadcast to channel " + REMOTE_PLAYER_UPDATE_CHANNEL + " reason: " + e.getMessage());
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -2,6 +2,7 @@ package com.playmonumenta.networkrelay;
 
 import java.util.Set;
 import java.util.UUID;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class RemotePlayerManagerAbstraction {
 	public abstract static class RemotePlayerAbstraction {
@@ -25,11 +26,11 @@ public abstract class RemotePlayerManagerAbstraction {
 	protected abstract boolean isPlayerOnline(String playerName);
 	protected abstract boolean isPlayerOnline(UUID playerUuid);
 
-	protected abstract String getPlayerShard(String playerName);
-	protected abstract String getPlayerShard(UUID playerUuid);
+	protected abstract @Nullable String getPlayerShard(String playerName);
+	protected abstract @Nullable String getPlayerShard(UUID playerUuid);
 
-	protected abstract RemotePlayerAbstraction getRemotePlayer(String playerName);
-	protected abstract RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
+	protected abstract @Nullable RemotePlayerAbstraction getRemotePlayer(String playerName);
+	protected abstract @Nullable RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
 
 	protected abstract boolean isPlayerVisible(String playerName);
 	protected abstract boolean isPlayerVisible(UUID playerUuid);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -8,6 +8,8 @@ public abstract class RemotePlayerManagerAbstraction {
 
 	protected abstract Set<String> getAllOnlinePlayersName(boolean visibleOnly);
 
+	protected abstract Set<UUID> getAllOnlinePlayersUuids(boolean visibleOnly);
+
 	protected abstract boolean isPlayerOnline(String playerName);
 
 	protected abstract boolean isPlayerOnline(UUID playerUuid);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -26,11 +26,15 @@ public abstract class RemotePlayerManagerAbstraction {
 	protected abstract boolean isPlayerOnline(String playerName);
 	protected abstract boolean isPlayerOnline(UUID playerUuid);
 
-	protected abstract @Nullable String getPlayerShard(String playerName);
-	protected abstract @Nullable String getPlayerShard(UUID playerUuid);
+	@Nullable
+	protected abstract  String getPlayerShard(String playerName);
+	@Nullable
+	protected abstract String getPlayerShard(UUID playerUuid);
 
-	protected abstract @Nullable RemotePlayerAbstraction getRemotePlayer(String playerName);
-	protected abstract @Nullable RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
+	@Nullable
+	protected abstract RemotePlayerAbstraction getRemotePlayer(String playerName);
+	@Nullable
+	protected abstract RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
 
 	protected abstract boolean isPlayerVisible(String playerName);
 	protected abstract boolean isPlayerVisible(UUID playerUuid);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -1,0 +1,36 @@
+package com.playmonumenta.networkrelay;
+
+import java.util.Set;
+import java.util.UUID;
+
+public abstract class RemotePlayerManagerAbstraction {
+	public abstract static class RemotePlayerAbstraction {
+		public final UUID mUuid;
+		public final String mName;
+		public final boolean mIsHidden;
+		public final boolean mIsOnline;
+		public final String mShard;
+
+        protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsHidden, boolean mIsOnline, String mShard) {
+            this.mUuid = mUuid;
+            this.mName = mName;
+            this.mIsHidden = mIsHidden;
+            this.mIsOnline = mIsOnline;
+            this.mShard = mShard;
+        }
+    }
+
+	protected abstract Set<String> getAllOnlinePlayersName(boolean visibleOnly);
+
+	protected abstract boolean isPlayerOnline(String playerName);
+	protected abstract boolean isPlayerOnline(UUID playerUuid);
+
+	protected abstract String getPlayerShard(String playerName);
+	protected abstract String getPlayerShard(UUID playerUuid);
+
+	protected abstract RemotePlayerAbstraction getRemotePlayer(String playerName);
+	protected abstract RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
+
+	protected abstract boolean isPlayerVisible(String playerName);
+	protected abstract boolean isPlayerVisible(UUID playerUuid);
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class RemotePlayerManagerAbstraction {
-	public static abstract class RemotePlayerAbstraction {
+	public abstract static class RemotePlayerAbstraction {
 		private final ConcurrentMap<String, JsonObject> mPluginData;
 		public final UUID mUuid;
 		public final String mName;

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -5,21 +5,21 @@ import java.util.UUID;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class RemotePlayerManagerAbstraction {
-	public abstract static class RemotePlayerAbstraction {
+	public static class RemotePlayerAbstraction {
 		public final UUID mUuid;
 		public final String mName;
 		public final boolean mIsHidden;
 		public final boolean mIsOnline;
 		public final String mShard;
 
-        protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsHidden, boolean mIsOnline, String mShard) {
-            this.mUuid = mUuid;
-            this.mName = mName;
-            this.mIsHidden = mIsHidden;
-            this.mIsOnline = mIsOnline;
-            this.mShard = mShard;
-        }
-    }
+		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsHidden, boolean mIsOnline, String mShard) {
+			this.mUuid = mUuid;
+			this.mName = mName;
+			this.mIsHidden = mIsHidden;
+			this.mIsOnline = mIsOnline;
+			this.mShard = mShard;
+		}
+	}
 
 	protected abstract Set<String> getAllOnlinePlayersName(boolean visibleOnly);
 
@@ -28,7 +28,7 @@ public abstract class RemotePlayerManagerAbstraction {
 	protected abstract boolean isPlayerOnline(UUID playerUuid);
 
 	@Nullable
-	protected abstract  String getPlayerShard(String playerName);
+	protected abstract String getPlayerShard(String playerName);
 
 	@Nullable
 	protected abstract String getPlayerShard(UUID playerUuid);

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -1,23 +1,76 @@
 package com.playmonumenta.networkrelay;
 
+import com.google.gson.JsonObject;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class RemotePlayerManagerAbstraction {
-	public static class RemotePlayerAbstraction {
+	public static abstract class RemotePlayerAbstraction {
+		private final ConcurrentMap<String, JsonObject> mPluginData;
 		public final UUID mUuid;
 		public final String mName;
-		public final boolean mIsHidden;
 		public final boolean mIsOnline;
 		public final String mShard;
 
-		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsHidden, boolean mIsOnline, String mShard) {
+		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsOnline, String mShard) {
 			this.mUuid = mUuid;
 			this.mName = mName;
-			this.mIsHidden = mIsHidden;
 			this.mIsOnline = mIsOnline;
 			this.mShard = mShard;
+			this.mPluginData = new ConcurrentHashMap<>();
+			mPluginData.putAll(gatherPluginData());
+		}
+
+		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsOnline, String mShard, JsonObject remoteData) {
+			this.mUuid = mUuid;
+			this.mName = mName;
+			this.mIsOnline = mIsOnline;
+			this.mShard = mShard;
+			this.mPluginData = deserializePluginData(remoteData);
+		}
+
+		protected abstract Map<String, JsonObject> gatherPluginData();
+
+		@Nullable
+		public JsonObject getPluginData(String pluginId) {
+			return mPluginData.get(pluginId);
+		}
+
+		protected ConcurrentMap<String, JsonObject> deserializePluginData(JsonObject remoteData) {
+			ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
+			// "plugins": {"plugin-name": {}}
+			JsonObject pluginData = remoteData.getAsJsonObject("plugins");
+			for (String key : pluginData.keySet()) {
+				pluginDataMap.put(key, pluginData.getAsJsonObject(key));
+			}
+			return pluginDataMap;
+		}
+
+		protected JsonObject serializePluginData() {
+			JsonObject pluginData = new JsonObject();
+			for (Map.Entry<String, JsonObject> entry : mPluginData.entrySet()) {
+				pluginData.add(entry.getKey(), entry.getValue());
+			}
+			return pluginData;
+		}
+	}
+
+	public static class RemotePlayerBungee extends RemotePlayerAbstraction {
+		public final String mProxy;
+
+		protected RemotePlayerBungee(UUID uuid, String name, boolean isOnline, String shard, String proxy) {
+			super(uuid, name, isOnline, shard);
+			this.mProxy = proxy;
+		}
+
+		@Override
+		protected Map<String, JsonObject> gatherPluginData() {
+			return new HashMap<>();
 		}
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -24,18 +24,22 @@ public abstract class RemotePlayerManagerAbstraction {
 	protected abstract Set<String> getAllOnlinePlayersName(boolean visibleOnly);
 
 	protected abstract boolean isPlayerOnline(String playerName);
+
 	protected abstract boolean isPlayerOnline(UUID playerUuid);
 
 	@Nullable
 	protected abstract  String getPlayerShard(String playerName);
+
 	@Nullable
 	protected abstract String getPlayerShard(UUID playerUuid);
 
 	@Nullable
 	protected abstract RemotePlayerAbstraction getRemotePlayer(String playerName);
+
 	@Nullable
 	protected abstract RemotePlayerAbstraction getRemotePlayer(UUID playerUuid);
 
 	protected abstract boolean isPlayerVisible(String playerName);
+
 	protected abstract boolean isPlayerVisible(UUID playerUuid);
 }

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerAbstraction.java
@@ -1,78 +1,10 @@
 package com.playmonumenta.networkrelay;
 
-import com.google.gson.JsonObject;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class RemotePlayerManagerAbstraction {
-	public abstract static class RemotePlayerAbstraction {
-		private final ConcurrentMap<String, JsonObject> mPluginData;
-		public final UUID mUuid;
-		public final String mName;
-		public final boolean mIsOnline;
-		public final String mShard;
-
-		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsOnline, String mShard) {
-			this.mUuid = mUuid;
-			this.mName = mName;
-			this.mIsOnline = mIsOnline;
-			this.mShard = mShard;
-			this.mPluginData = new ConcurrentHashMap<>();
-			mPluginData.putAll(gatherPluginData());
-		}
-
-		protected RemotePlayerAbstraction(UUID mUuid, String mName, boolean mIsOnline, String mShard, JsonObject remoteData) {
-			this.mUuid = mUuid;
-			this.mName = mName;
-			this.mIsOnline = mIsOnline;
-			this.mShard = mShard;
-			this.mPluginData = deserializePluginData(remoteData);
-		}
-
-		protected abstract Map<String, JsonObject> gatherPluginData();
-
-		@Nullable
-		public JsonObject getPluginData(String pluginId) {
-			return mPluginData.get(pluginId);
-		}
-
-		protected ConcurrentMap<String, JsonObject> deserializePluginData(JsonObject remoteData) {
-			ConcurrentMap<String, JsonObject> pluginDataMap = new ConcurrentHashMap<>();
-			// "plugins": {"plugin-name": {}}
-			JsonObject pluginData = remoteData.getAsJsonObject("plugins");
-			for (String key : pluginData.keySet()) {
-				pluginDataMap.put(key, pluginData.getAsJsonObject(key));
-			}
-			return pluginDataMap;
-		}
-
-		protected JsonObject serializePluginData() {
-			JsonObject pluginData = new JsonObject();
-			for (Map.Entry<String, JsonObject> entry : mPluginData.entrySet()) {
-				pluginData.add(entry.getKey(), entry.getValue());
-			}
-			return pluginData;
-		}
-	}
-
-	public static class RemotePlayerBungee extends RemotePlayerAbstraction {
-		public final String mProxy;
-
-		protected RemotePlayerBungee(UUID uuid, String name, boolean isOnline, String shard, String proxy) {
-			super(uuid, name, isOnline, shard);
-			this.mProxy = proxy;
-		}
-
-		@Override
-		protected Map<String, JsonObject> gatherPluginData() {
-			return new HashMap<>();
-		}
-	}
 
 	protected abstract Set<String> getAllOnlinePlayersName(boolean visibleOnly);
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
@@ -102,6 +102,15 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 	}
 
 	@Override
+	protected Set<UUID> getAllOnlinePlayersUuids(boolean visibleOnly) {
+		Set<UUID> visible = new HashSet<>(mRemotePlayersByUuid.keySet());
+		if (visibleOnly) {
+			visible.removeAll(getHiddenPlayerUuids());
+		}
+		return visible;
+	}
+
+	@Override
 	protected boolean isPlayerOnline(UUID playerUuid) {
 		return mRemotePlayersByUuid.containsKey(playerUuid);
 	}
@@ -115,6 +124,14 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 		Set<String> results = new ConcurrentSkipListSet<>();
 		for (UUID playerUuid : mHiddenPlayers) {
 			results.add(getPlayerName(playerUuid));
+		}
+		return results;
+	}
+
+	protected Set<UUID> getHiddenPlayerUuids() {
+		Set<UUID> results = new ConcurrentSkipListSet<>();
+		for (UUID playerUuid : mHiddenPlayers) {
+			results.add(playerUuid);
 		}
 		return results;
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
@@ -34,7 +34,7 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 		}
 
 		public RemotePlayerPaper(UUID mUuid, String mName, boolean mIsHidden, boolean mIsOnline, String mShard, JsonObject remoteData) {
-			super(mUuid, mName, mIsOnline, mShard);
+			super(mUuid, mName, mIsOnline, mShard, remoteData);
 			this.mIsHidden = mIsHidden;
 
 			MMLog.fine("Received RemotePlayerState for " + mName + " from " + mShard + ": " + (mIsOnline ? "online" : "offline"));

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerManagerPaper.java
@@ -154,6 +154,7 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 		return shardName;
 	}
 
+	@Override
 	protected Set<String> getAllOnlinePlayersName(boolean visibleOnly) {
 		if (visibleOnly) {
 			return getVisiblePlayerNames();
@@ -161,10 +162,12 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 		return new HashSet<>(mRemotePlayersByName.keySet());
 	}
 
+	@Override
 	protected boolean isPlayerOnline(UUID playerUuid) {
 		return mRemotePlayersByUuid.containsKey(playerUuid);
 	}
 
+	@Override
 	protected boolean isPlayerOnline(String playerName) {
 		return mRemotePlayersByName.containsKey(playerName);
 	}
@@ -195,10 +198,12 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 		return currentResult;
 	}
 
+	@Override
 	protected boolean isPlayerVisible(UUID playerUuid) {
 		return mVisiblePlayers.contains(playerUuid);
 	}
 
+	@Override
 	protected boolean isPlayerVisible(String playerName) {
 		@Nullable UUID playerUuid = getPlayerUuid(playerName);
 		if (playerUuid == null) {
@@ -232,6 +237,7 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 	}
 
 	@Nullable
+	@Override
 	protected String getPlayerShard(@NotNull String username) {
 		@Nullable RemotePlayer remotePlayer = getRemotePlayer(username);
 		if (remotePlayer == null) {
@@ -241,6 +247,7 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 	}
 
 	@Nullable
+	@Override
 	protected String getPlayerShard(@NotNull UUID playerUuid) {
 		@Nullable RemotePlayer remotePlayer = getRemotePlayer(playerUuid);
 		if (remotePlayer == null) {
@@ -250,11 +257,13 @@ public class RemotePlayerManagerPaper extends RemotePlayerManagerAbstraction imp
 	}
 
 	@Nullable
+	@Override
 	protected RemotePlayer getRemotePlayer(@NotNull String username) {
 		return mRemotePlayersByName.get(username);
 	}
 
 	@Nullable
+	@Override
 	protected RemotePlayer getRemotePlayer(@Nullable UUID playerUuid) {
 		if (playerUuid == null) {
 			return null;

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerPaper.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerPaper.java
@@ -1,0 +1,82 @@
+package com.playmonumenta.networkrelay;
+
+import com.google.gson.JsonObject;
+import com.playmonumenta.networkrelay.util.MMLog;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+
+public class RemotePlayerPaper extends RemotePlayerAbstraction {
+	protected static final String SERVER_TYPE = "minecraft";
+	private final boolean mIsHidden;
+	private final String mShard;
+	private final String mWorld;
+
+	protected RemotePlayerPaper(UUID uuid, String name, boolean isHidden, boolean isOnline, String shard, String world) {
+		super(uuid, name, isOnline);
+		mIsHidden = isHidden;
+		mShard = shard;
+		mWorld = world;
+
+		MMLog.fine("Created RemotePlayerState for " + mName + " from " + mShard + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	protected RemotePlayerPaper(UUID uuid, String name, boolean isHidden, boolean isOnline, String shard, String world, JsonObject remoteData) {
+		super(uuid, name, isOnline, remoteData);
+		mIsHidden = isHidden;
+		mShard = shard;
+		mWorld = world;
+
+		MMLog.fine("Received RemotePlayerState for " + mName + " from " + mShard + ": " + (mIsOnline ? "online" : "offline"));
+	}
+
+	@Override
+	protected Map<String, JsonObject> gatherPluginData() {
+		GatherRemotePlayerDataEvent event = new GatherRemotePlayerDataEvent();
+		Bukkit.getPluginManager().callEvent(event);
+		return event.getPluginData();
+	}
+
+	protected static RemotePlayerPaper paperFrom(JsonObject remoteData) {
+		UUID uuid = UUID.fromString(remoteData.get("playerUuid").getAsString());
+		String name = remoteData.get("playerName").getAsString();
+		boolean isOnline = remoteData.get("isOnline").getAsBoolean();
+		boolean isHidden = remoteData.get("isHidden").getAsBoolean();
+		String shard = remoteData.get("shard").getAsString();
+		String world = remoteData.get("world").getAsString();
+		return new RemotePlayerPaper(uuid, name, isHidden, isOnline, shard, world, remoteData);
+	}
+
+	protected void broadcast() {
+		JsonObject remotePlayerData = new JsonObject();
+		remotePlayerData.addProperty("serverType", SERVER_TYPE);
+		remotePlayerData.addProperty("playerUuid", mUuid.toString());
+		remotePlayerData.addProperty("playerName", mName);
+		remotePlayerData.addProperty("isHidden", mIsHidden);
+		remotePlayerData.addProperty("isOnline", mIsOnline);
+		remotePlayerData.addProperty("shard", mShard);
+		remotePlayerData.addProperty("world", mWorld);
+		remotePlayerData.add("plugins", serializePluginData());
+
+		try {
+			NetworkRelayAPI.sendExpiringBroadcastMessage(RemotePlayerManagerPaper.REMOTE_PLAYER_UPDATE_CHANNEL,
+				remotePlayerData,
+				RemotePlayerManagerPaper.REMOTE_PLAYER_MESSAGE_TTL);
+		} catch (Exception e) {
+			MMLog.severe("Failed to broadcast " + RemotePlayerManagerPaper.REMOTE_PLAYER_UPDATE_CHANNEL);
+		}
+	}
+
+	@Override
+	public String getServerType() {
+		return SERVER_TYPE;
+	}
+
+	public String getShard() {
+		return mShard;
+	}
+
+	public boolean isHidden() {
+		return mIsHidden;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
@@ -1,0 +1,25 @@
+package com.playmonumenta.networkrelay;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class RemotePlayerUnloadedEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+
+	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
+	public final String mShard;
+	public RemotePlayerUnloadedEvent(@NotNull RemotePlayerManager.RemotePlayer remotePlayer) {
+		mRemotePlayer = remotePlayer;
+		mShard = remotePlayer.mShard;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
@@ -6,10 +6,10 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerUnloadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManagerPaper.RemotePlayer mRemotePlayer;
+	public final RemotePlayerManagerPaper.RemotePlayerPaper mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerUnloadedEvent(RemotePlayerManagerPaper.RemotePlayer remotePlayer) {
+	public RemotePlayerUnloadedEvent(RemotePlayerManagerPaper.RemotePlayerPaper remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
@@ -6,12 +6,12 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerUnloadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManagerPaper.RemotePlayerPaper mRemotePlayer;
+	public final RemotePlayerPaper mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerUnloadedEvent(RemotePlayerManagerPaper.RemotePlayerPaper remotePlayer) {
+	public RemotePlayerUnloadedEvent(RemotePlayerPaper remotePlayer) {
 		mRemotePlayer = remotePlayer;
-		mShard = remotePlayer.mShard;
+		mShard = remotePlayer.getShard();
 	}
 
 	@Override

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
@@ -2,20 +2,20 @@ package com.playmonumenta.networkrelay;
 
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class RemotePlayerUnloadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
 	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
 	public final String mShard;
-	public RemotePlayerUnloadedEvent(@NotNull RemotePlayerManager.RemotePlayer remotePlayer) {
+
+	public RemotePlayerUnloadedEvent(RemotePlayerManager.RemotePlayer remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}
 
 	@Override
-	public @NotNull HandlerList getHandlers() {
+	public HandlerList getHandlers() {
 		return handlers;
 	}
 

--- a/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
+++ b/src/main/java/com/playmonumenta/networkrelay/RemotePlayerUnloadedEvent.java
@@ -6,10 +6,10 @@ import org.bukkit.event.HandlerList;
 public class RemotePlayerUnloadedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
-	public final RemotePlayerManager.RemotePlayer mRemotePlayer;
+	public final RemotePlayerManagerPaper.RemotePlayer mRemotePlayer;
 	public final String mShard;
 
-	public RemotePlayerUnloadedEvent(RemotePlayerManager.RemotePlayer remotePlayer) {
+	public RemotePlayerUnloadedEvent(RemotePlayerManagerPaper.RemotePlayer remotePlayer) {
 		mRemotePlayer = remotePlayer;
 		mShard = remotePlayer.mShard;
 	}

--- a/src/main/java/com/playmonumenta/networkrelay/util/MMLog.java
+++ b/src/main/java/com/playmonumenta/networkrelay/util/MMLog.java
@@ -1,0 +1,70 @@
+package com.playmonumenta.networkrelay.util;
+
+import com.playmonumenta.networkrelay.CustomLogger;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+public class MMLog {
+	public static void setLevel(Level level) {
+		CustomLogger.getInstance()
+			.ifPresent(value -> value.setLevel(level));
+	}
+
+	public static boolean isLevelEnabled(Level level) {
+		return CustomLogger.getInstance()
+			.map(customLogger -> level.intValue() >= customLogger.getLevel().intValue())
+			.orElse(true);
+	}
+
+	public static void finest(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.finest(msg));
+	}
+
+	public static void finest(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.finest(msg));
+	}
+
+	public static void finer(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.finer(msg));
+	}
+
+	public static void finer(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.finer(msg));
+	}
+
+	public static void fine(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.fine(msg));
+	}
+
+	public static void fine(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.fine(msg));
+	}
+
+	public static void info(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.info(msg));
+	}
+
+	public static void info(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.info(msg));
+	}
+
+	public static void warning(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.warning(msg));
+	}
+
+	public static void warning(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.warning(msg));
+	}
+
+	public static void warning(String msg, Throwable t) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.log(Level.WARNING, msg, t));
+	}
+
+	public static void severe(Supplier<String> msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.severe(msg));
+	}
+
+	public static void severe(String msg) {
+		CustomLogger.getInstance().ifPresent(customLogger -> customLogger.severe(msg));
+	}
+}


### PR DESCRIPTION
On top of the port:
	 - Added the ability to register plugin data on the remote player messages.
	 - Added event GatherRemotePlayerDataEvent to gather the plugin data to be added on the remote player messages.
	 - Added events RemotePlayerLoadedEvent & RemotePlayerUnloadedEvent to get an easier way to listen to changes in the full online player list.